### PR TITLE
Q4 22 updates

### DIFF
--- a/start-devday-build.sh
+++ b/start-devday-build.sh
@@ -1,7 +1,7 @@
-DG="\033[1;30m"
-RD="\033[0;31m"
+# DG="\033[1;30m"
+# RD="\033[0;31m"
 NC="\033[0;0m"
-LB="\033[1;34m"
+# LB="\033[1;34m"
 env_up(){
    
     #git clone https://github.com/CrowdStrike/devdays.git
@@ -13,13 +13,13 @@ env_up(){
    StackName=${S3Bucket}
    TemplateName='entry.yaml'
 
-   echo -e "$LB\n"
-   echo -e "Welcome to DevDays$NC"
-   echo -e "$LB\n"
+   echo 
+   echo -e "Welcome to Dev Days$NC"
+   echo 
    echo -e "You will asked to provide a Falcon API Key Client ID and Secret." 
    echo -e "You can create one at https://falcon.crowdstrike.com/support/api-clients-and-keys"
-   echo -e "$LB\n"
-   echo -e "The ev Days Workshop environment requires the following API Scope permissions:"
+   echo 
+   echo -e "The Dev Days Workshop environment requires the following API Scope permissions:"
    echo -e " - AWS Accounts:R"
    echo -e " - CSPM registration:R/W"
    echo -e " - CSPM remediation:R/W"
@@ -30,17 +30,21 @@ env_up(){
    echo -e " - Kubernetes Protection Agent:W"
    echo -e " - Sensor Download:R"
    echo -e " - Event streams:R"
+   echo
    read -p "Enter your Falcon API Key Client ID: " CLIENT_ID
    read -p "Enter your Falcon API Key Client Secret: " CLIENT_SECRET
+   echo
    echo -e "For the next variable (Falcon CID), use the entire string include the 2-character hash which you can find at https://falcon.crowdstrike.com/hosts/sensor-downloads"
    read -p "Enter your Falcon CID: " CS_CID
+   echo
    echo -e "You can find your Docker API Token at https://falcon.crowdstrike.com/cloud-security/registration?return_to=eks."
    echo -e "Click 'Register new Kubernetes Cluster' > 'Self-Managed Kubernetes Service' > enter any random string in the 'Cluster Name' field > Click 'Generate'"
    echo -e "Copy the value for 'dockerAPIToken' from the script that appears and use it below"
    read -p "Enter your Falcon Docker API Token: " DOCKER_API_TOKEN
    read -p "Enter your Falcon Cloud [us-1]: " CS_CLOUD
    CS_CLOUD=${CS_CLOUD:-us-1}
-   echo -e "Enter an existing key-pair in us-east-1 for connecting to EC2 instances. Yo can create one at https://us-east-1.console.aws.amazon.com/ec2#KeyPairs:"
+   echo
+   echo -e "Enter an existing key-pair in us-east-1 for connecting to EC2 instances. You can create one at https://us-east-1.console.aws.amazon.com/ec2#KeyPairs:"
    read -p "Enter your EC2 key-pair name [cs-key]: " KeyPairName
    KeyPairName=${KeyPairName:-cs-key}
 
@@ -48,7 +52,7 @@ env_up(){
    
    cd templates
    aws s3 cp . s3://${S3Bucket}/${S3Prefix} --recursive 
-   echo -e "$LB\n"
+   echo
    echo -e "Standing up environment...$NC"
 
    aws cloudformation create-stack --stack-name $StackName --template-url https://${S3Bucket}.s3.amazonaws.com/${S3Prefix}/${TemplateName} --region $AWS_REGION --disable-rollback \
@@ -61,7 +65,8 @@ env_up(){
    ParameterKey=FalconClientSecret,ParameterValue=$CLIENT_SECRET \
    ParameterKey=CrowdStrikeCloud,ParameterValue=$CS_CLOUD \
    ParameterKey=FalconCID,ParameterValue=$CS_CID \
-   ParameterKey=DockerAPIToken,ParameterValue=$DOCKER_API_TOKEN
+   ParameterKey=DockerAPIToken,ParameterValue=$DOCKER_API_TOKEN \
+   ParameterKey=EnvHash,ParameterValue=$EnvHash
 
     echo -e "The Cloudformation stack will take 20-30 minutes to complete.$NC"
     echo -e "\n\nCheck the status at any time with the command \n\naws cloudformation describe-stacks --stack-name devdays-cnap-stack --region $AWS_REGION$NC\n\n"

--- a/templates/bastionSetup.sh
+++ b/templates/bastionSetup.sh
@@ -8,7 +8,8 @@ function setup_environment_variables() {
 function install_kubernetes_client_tools() {
     printf "\nInstall K8s Client Tools"
     mkdir -p /usr/local/bin/
-    curl --retry 5 -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/kubectl
+    # curl --retry 5 -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/kubectl
+    curl --retry 5 -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/amd64/kubectl
     chmod +x ./kubectl
     mv ./kubectl /usr/local/bin/
     mkdir -p /root/bin
@@ -19,7 +20,8 @@ function install_kubernetes_client_tools() {
 source <(/usr/local/bin/kubectl completion bash)
 EOF
     chmod +x /etc/profile.d/kubectl.sh
-    curl --retry 5 -o helm.tar.gz https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz
+    # curl --retry 5 -o helm.tar.gz https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz
+    curl --retry 5 -o helm.tar.gz https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz
     tar -xvf helm.tar.gz
     chmod +x ./linux-amd64/helm
     mv ./linux-amd64/helm /usr/local/bin/helm
@@ -75,6 +77,7 @@ EOF
     mkdir -p /home/ssm-user/.kube/
     cp /home/ec2-user/.kube/config /home/ssm-user/.kube/config
     chown -R ssm-user:ssm-user /home/ssm-user/
+    chmod -R og-rwx /home/ssm-user/.kube
 }
 
 function setup_nodesensor_config(){
@@ -102,7 +105,7 @@ function setup_k8s_agent_config(){
 crowdstrikeConfig:
   clientID: ${CS_CLIENT_ID}
   clientSecret: ${CS_CLIENT_SECRET}
-  clusterName: ${K8S_CLUSTER_NAME}
+  clusterName: "arn:aws:eks:${region}:${accountId}:cluster/${K8S_CLUSTER_NAME}"
   env: ${CS_ENV}
   cid: ${CS_CID_LOWER}
   dockerAPIToken: ${DOCKER_API_TOKEN}

--- a/templates/bastionSetup.sh
+++ b/templates/bastionSetup.sh
@@ -20,13 +20,20 @@ function install_kubernetes_client_tools() {
 source <(/usr/local/bin/kubectl completion bash)
 EOF
     chmod +x /etc/profile.d/kubectl.sh
-    # curl --retry 5 -o helm.tar.gz https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz
     curl --retry 5 -o helm.tar.gz https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz
+    # curl --retry 5 -o helm.tar.gz https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz
     tar -xvf helm.tar.gz
     chmod +x ./linux-amd64/helm
     mv ./linux-amd64/helm /usr/local/bin/helm
     ln -s /usr/local/bin/helm /opt/aws/bin
     rm -rf ./linux-amd64/
+# Install awscli v2
+    curl -O "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    unzip -o awscli-exe-linux-x86_64.zip
+    sudo ./aws/install
+    rm awscli-exe-linux-x86_64.zip
+    mv /bin/aws /bin/aws.v1
+    ln -s /usr/local/aws-cli/v2/current/dist/aws /bin/aws
 }
 
 function setup_kubeconfig() {
@@ -82,7 +89,7 @@ EOF
 
 function setup_nodesensor_config(){
     cat >/tmp/node_sensor.yaml <<EOF
-apiVersion: falcon.crowdstrike.com/v1alpha1
+apiVersion: falcon.crowdstrike.com/v1beta1
 kind: FalconNodeSensor
 metadata:
   name: falcon-node-sensor
@@ -105,7 +112,7 @@ function setup_k8s_agent_config(){
 crowdstrikeConfig:
   clientID: ${CS_CLIENT_ID}
   clientSecret: ${CS_CLIENT_SECRET}
-  clusterName: "arn:aws:eks:${region}:${accountId}:cluster/${K8S_CLUSTER_NAME}"
+  clusterName: arn:aws:eks:${region}:${accountId}:cluster/${K8S_CLUSTER_NAME}
   env: ${CS_ENV}
   cid: ${CS_CID_LOWER}
   dockerAPIToken: ${DOCKER_API_TOKEN}

--- a/templates/bastionSetup.sh
+++ b/templates/bastionSetup.sh
@@ -59,7 +59,7 @@ users:
 - name: ${clusterArn}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws
       args:
         - --region
@@ -89,7 +89,7 @@ EOF
 
 function setup_nodesensor_config(){
     cat >/tmp/node_sensor.yaml <<EOF
-apiVersion: falcon.crowdstrike.com/v1beta1
+apiVersion: falcon.crowdstrike.com/v1alpha1
 kind: FalconNodeSensor
 metadata:
   name: falcon-node-sensor

--- a/templates/eksControlPlane.yaml
+++ b/templates/eksControlPlane.yaml
@@ -74,7 +74,7 @@ Resources:
         config:
           ignore_checks: [ E3001 ]
     Properties:
-      Name: !Sub '${EnvAlias}-EKS-Cluster'
+      Name: !Sub '${EnvAlias}-EKS-Cluster-${EnvHash}'
       ResourcesVpcConfig:
         EndpointPrivateAccess: true
         EndpointPublicAccess: true


### PR DESCRIPTION
Updating Helm and Kubectl versions which required new kubeconfig file specifying client.authentication.k8s.io/v1beta1 instead of client.authentication.k8s.io/v1alpha1. Also, required awscli v2. v1 is installed on AL2 instances by default.