### PR TITLE
fix logging bucket ownership

### DIFF
--- a/templates/vulBucket.yaml
+++ b/templates/vulBucket.yaml
@@ -32,6 +32,9 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Properties:
       AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
   CopyRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
add bucket ownership control "bucket owner preferred" to resolve "InvalidBucketAclWithObjectOwnership" error on ConfidentialLoggingBucket